### PR TITLE
Fix non-working code

### DIFF
--- a/src/gcloud.rs
+++ b/src/gcloud.rs
@@ -1,14 +1,16 @@
 use std::process::Command;
 
-static error_message: &str = "Failed to run gcloud command.";
+pub fn get_project_list() -> Vec<String> {
+    let command_output = Command::new("gcloud")
+        .arg("projects")
+        .arg("list")
+        .arg("--verbosity=none")
+        .output()
+        .expect("Failed to run gcloud command.");
 
-pub fn get_project_list<'a>() -> &'a Vec<&'a str> {
-    let command_output =
-        Command::new("gcloud")
-                .arg("projects").arg("list").arg("--verbosity=none")
-                .output().expect("Failed to run gcloud command.");
-
-    // Ignore first row because those are just titles.
-    let parsed_rows = String::from_utf8_lossy(&command_output.stdout).lines().collect::<Vec<&str>>();
-    return &parsed_rows[1..].to_vec();
+    String::from_utf8_lossy(&command_output.stdout)
+        .lines()
+        .skip(1)
+        .map(|x| x.to_string())
+        .collect()
 }


### PR DESCRIPTION
This is probably not the most elegant solution to fix this but at least it demonstrates what was wrong with the code.

The problem we had was not because of returning an iterator. It was about returning local variables (like you guessed).

For example:
``` rust
pub fn get_project_list<'a>() -> impl Iterator<Item = &'a str> {
    ...
    String::from_utf8_lossy(&command_output.stdout).lines().skip(1)
}
```
This does not work because the returned string `&'a str` has same lifetime as `command_output` variable and `command_output` variable is dropped after `get_project_list` function is executed.